### PR TITLE
Fixed MSVR-reported XSS error on sds login page

### DIFF
--- a/sds/login/certs/login.php
+++ b/sds/login/certs/login.php
@@ -45,9 +45,11 @@ require_once("../../sds.php");
 if(empty($sdsToURL)) {
   if(!empty($_REQUEST['url'])) {
     $sdsToURL = maybeStripslashes($_REQUEST["url"]);
+    // Microsoft-reported security problem:
+    $stsToURL = htmlspecialchars($sdsToURL);
   } else {
     $sdsToURL = SDS_HOME_URL;
-  }
+	}
 }
 
 $sdsToArgs = '';


### PR DESCRIPTION
Fixed XSS error where "?url=" query argument was improperly echoed into html elements on the login page.
