### PR TITLE
Fixed MSVR-reported XSS error on simmons sds login page

### DIFF
--- a/sds/login/certs/login.php
+++ b/sds/login/certs/login.php
@@ -46,10 +46,10 @@ if(empty($sdsToURL)) {
   if(!empty($_REQUEST['url'])) {
     $sdsToURL = maybeStripslashes($_REQUEST["url"]);
     // Microsoft-reported security problem:
-    $stsToURL = htmlspecialchars($sdsToURL);
+    $sdsToURL = htmlspecialchars($sdsToURL);
   } else {
     $sdsToURL = SDS_HOME_URL;
-	}
+  }
 }
 
 $sdsToArgs = '';


### PR DESCRIPTION
Fixed XSS error where "?url=" query argument was improperly echoed into html elements on the login page.
