### PR TITLE
Fixed link to non-existent government.html page

### DIFF
--- a/about.html
+++ b/about.html
@@ -138,6 +138,16 @@
       <a class="carousel-control left" href="#myCarousel" data-slide="prev">&lsaquo;</a>
       <a class="carousel-control right" href="#myCarousel" data-slide="next">&rsaquo;</a>
     </div>
+      <h2>Simmons Government</h2>
+      <p>Simmons has its own unique government structure. From our
+      student led initiatives to our unique social "lounge" structure
+      to our open house meetings and proposals, we have so much to get
+      involved with.</p>
+
+      <p>Contact the Simmons officers
+      at <a href="mailto:officers@simmons.mit.edu">officers@simmons.mit.edu</a>.
+    
+      
 
       <h2>Housemasters</h2>
       <p>The Housemaster team consists of <a
@@ -164,7 +174,6 @@
       Simmons Hall they can also be found flipping pancakes at the
       famous Simmons Hall Study Breaks and organizing floor-wide
       events.</p>
-      
       
 
       <h2>Residential Life Associate Director (RLAD)</h2> 

--- a/residents.html
+++ b/residents.html
@@ -68,13 +68,6 @@
 	<p>Contact our Reservations Chair at <a href="mailto:simmons-reservations@mit.edu">
 	simmons-reserve@mit.edu</a> for more info.</p>
 	
-	<h2><a href="government.html">Simmons Government</a></h2>
-	<p>Simmons has its own unique government structure. From our student led initiatives to our unique social "lounge"
-	structure to our open house meetings and proposals, we have so much to get involved with. Click the link above to 
-	learn more.</p>
-	
-	<p>Contact the Simmons officers at <a href="mailto:officers@simmons.mit.edu">officers@simmons.mit.edu</a>.
-    
     <h2><a href="http://web.mit.edu/simmons/tech">Simmons Tech</a></h2>
     <p>Simmons has an active Tech committee that takes care of all tech-related
 	things at Simmons. View all the things we do here!</p>


### PR DESCRIPTION
Fixes a prior commit that introduced a link to a government.html page which did not exist. Moved description of government to the about page.
